### PR TITLE
Fix the bug in lab_result/kern/mm/vmm.c

### DIFF
--- a/labcodes/lab3/kern/mm/swap_fifo.c
+++ b/labcodes/lab3/kern/mm/swap_fifo.c
@@ -102,6 +102,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes/lab4/kern/mm/swap_fifo.c
+++ b/labcodes/lab4/kern/mm/swap_fifo.c
@@ -102,6 +102,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes/lab5/kern/mm/swap_fifo.c
+++ b/labcodes/lab5/kern/mm/swap_fifo.c
@@ -102,6 +102,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes/lab6/kern/mm/swap_fifo.c
+++ b/labcodes/lab6/kern/mm/swap_fifo.c
@@ -102,6 +102,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes/lab7/kern/mm/swap_fifo.c
+++ b/labcodes/lab7/kern/mm/swap_fifo.c
@@ -102,6 +102,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes/lab8/kern/mm/swap_fifo.c
+++ b/labcodes/lab8/kern/mm/swap_fifo.c
@@ -102,6 +102,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes_answer/lab3_result/kern/mm/swap_fifo.c
+++ b/labcodes_answer/lab3_result/kern/mm/swap_fifo.c
@@ -110,6 +110,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes_answer/lab3_result/kern/mm/vmm.c
+++ b/labcodes_answer/lab3_result/kern/mm/vmm.c
@@ -419,6 +419,7 @@ do_pgfault(struct mm_struct *mm, uint32_t error_code, uintptr_t addr) {
             }    
             page_insert(mm->pgdir, page, addr, perm);
             swap_map_swappable(mm, addr, page, 1);
+            page->pra_vaddr = addr;
         }
         else {
             cprintf("no swap_init_ok but ptep is %x, failed\n",*ptep);

--- a/labcodes_answer/lab4_result/kern/mm/swap_fifo.c
+++ b/labcodes_answer/lab4_result/kern/mm/swap_fifo.c
@@ -110,6 +110,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes_answer/lab4_result/kern/mm/vmm.c
+++ b/labcodes_answer/lab4_result/kern/mm/vmm.c
@@ -420,6 +420,7 @@ do_pgfault(struct mm_struct *mm, uint32_t error_code, uintptr_t addr) {
             }    
             page_insert(mm->pgdir, page, addr, perm);
             swap_map_swappable(mm, addr, page, 1);
+            page->pra_vaddr = addr;
         }
         else {
             cprintf("no swap_init_ok but ptep is %x, failed\n",*ptep);

--- a/labcodes_answer/lab5_result/kern/mm/swap_fifo.c
+++ b/labcodes_answer/lab5_result/kern/mm/swap_fifo.c
@@ -110,6 +110,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes_answer/lab5_result/kern/mm/vmm.c
+++ b/labcodes_answer/lab5_result/kern/mm/vmm.c
@@ -527,6 +527,7 @@ do_pgfault(struct mm_struct *mm, uint32_t error_code, uintptr_t addr) {
        } 
        page_insert(mm->pgdir, page, addr, perm);
        swap_map_swappable(mm, addr, page, 1);
+       page->pra_vaddr = addr;
    }
    ret = 0;
 failed:

--- a/labcodes_answer/lab6_result/kern/mm/swap_fifo.c
+++ b/labcodes_answer/lab6_result/kern/mm/swap_fifo.c
@@ -110,6 +110,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes_answer/lab6_result/kern/mm/vmm.c
+++ b/labcodes_answer/lab6_result/kern/mm/vmm.c
@@ -527,6 +527,7 @@ do_pgfault(struct mm_struct *mm, uint32_t error_code, uintptr_t addr) {
        } 
        page_insert(mm->pgdir, page, addr, perm);
        swap_map_swappable(mm, addr, page, 1);
+       page->pra_vaddr = addr;
    }
    ret = 0;
 failed:

--- a/labcodes_answer/lab7_result/kern/mm/swap_fifo.c
+++ b/labcodes_answer/lab7_result/kern/mm/swap_fifo.c
@@ -110,6 +110,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes_answer/lab7_result/kern/mm/vmm.c
+++ b/labcodes_answer/lab7_result/kern/mm/vmm.c
@@ -536,6 +536,7 @@ do_pgfault(struct mm_struct *mm, uint32_t error_code, uintptr_t addr) {
        } 
        page_insert(mm->pgdir, page, addr, perm);
        swap_map_swappable(mm, addr, page, 1);
+       page->pra_vaddr = addr;
    }
    ret = 0;
 failed:

--- a/labcodes_answer/lab8_result/kern/mm/swap_fifo.c
+++ b/labcodes_answer/lab8_result/kern/mm/swap_fifo.c
@@ -110,6 +110,13 @@ _fifo_check_swap(void) {
     cprintf("write Virt Page d in fifo_check_swap\n");
     *(unsigned char *)0x4000 = 0x0d;
     assert(pgfault_num==9);
+    cprintf("write Virt Page e in fifo_check_swap\n");
+    *(unsigned char *)0x5000 = 0x0e;
+    assert(pgfault_num==10);
+    cprintf("write Virt Page a in fifo_check_swap\n");
+    assert(*(unsigned char *)0x1000 == 0x0a);
+    *(unsigned char *)0x1000 = 0x0a;
+    assert(pgfault_num==11);
     return 0;
 }
 

--- a/labcodes_answer/lab8_result/kern/mm/vmm.c
+++ b/labcodes_answer/lab8_result/kern/mm/vmm.c
@@ -536,6 +536,7 @@ do_pgfault(struct mm_struct *mm, uint32_t error_code, uintptr_t addr) {
        } 
        page_insert(mm->pgdir, page, addr, perm);
        swap_map_swappable(mm, addr, page, 1);
+       page->pra_vaddr = addr;
    }
    ret = 0;
 failed:


### PR DESCRIPTION
The "page_insert(mm->pgdir, page, addr, perm)" and "swap_map_swappable(mm, addr, page, 1)" in do_pgfault must be followed with "page->pra_vaddr = addr", otherwise the check I have added won't be passed