### PR TITLE
Fix the bug when empty run_link

### DIFF
--- a/labcodes_answer/lab6_result/kern/process/proc.c
+++ b/labcodes_answer/lab6_result/kern/process/proc.c
@@ -118,7 +118,7 @@ alloc_proc(void) {
         proc->wait_state = 0;
         proc->cptr = proc->optr = proc->yptr = NULL;
         proc->rq = NULL;
-        proc->run_link.prev = proc->run_link.next = NULL;
+        list_init(&(proc->run_link));
         proc->time_slice = 0;
         proc->lab6_run_pool.left = proc->lab6_run_pool.right = proc->lab6_run_pool.parent = NULL;
         proc->lab6_stride = 0;

--- a/labcodes_answer/lab7_result/kern/process/proc.c
+++ b/labcodes_answer/lab7_result/kern/process/proc.c
@@ -124,7 +124,7 @@ alloc_proc(void) {
         proc->wait_state = 0;
         proc->cptr = proc->optr = proc->yptr = NULL;
         proc->rq = NULL;
-        proc->run_link.prev = proc->run_link.next = NULL;
+        list_init(&(proc->run_link));
         proc->time_slice = 0;
         proc->lab6_run_pool.left = proc->lab6_run_pool.right = proc->lab6_run_pool.parent = NULL;
         proc->lab6_stride = 0;

--- a/labcodes_answer/lab8_result/kern/process/proc.c
+++ b/labcodes_answer/lab8_result/kern/process/proc.c
@@ -128,7 +128,7 @@ alloc_proc(void) {
         proc->wait_state = 0;
         proc->cptr = proc->optr = proc->yptr = NULL;
         proc->rq = NULL;
-        proc->run_link.prev = proc->run_link.next = NULL;
+        list_init(&(proc->run_link));
         proc->time_slice = 0;
         proc->lab6_run_pool.left = proc->lab6_run_pool.right = proc->lab6_run_pool.parent = NULL;
         proc->lab6_stride = 0;


### PR DESCRIPTION
I use "list_init(&(proc->run_link))" to make sure that  the "list_empty(&(proc->run_link))" will be true , which will be checked when use Round-Robin or Stride Scheduling implemented with list.